### PR TITLE
fix/asg-desired: fix current desired_capacity to >= min

### DIFF
--- a/tasks/aws-asg.yml
+++ b/tasks/aws-asg.yml
@@ -30,6 +30,7 @@
       desired_capacity: "{{ item_scale.asg_spec.min_size }}"
   when:
     - ret_asg.results is defined
+    - ret_asg.results|length > 0
     - ret_asg.results[0].desired_capacity < item_scale.asg_spec.min_size
 
 - name: aws | asg | Create

--- a/tasks/aws-asg.yml
+++ b/tasks/aws-asg.yml
@@ -24,6 +24,14 @@
     - ret_asg.results is defined
     - ret_asg.results|length == 0
 
+- name: aws | asg | fix current desired_capacity to >= min
+  set_fact:
+    asg_spec_des:
+      desired_capacity: "{{ item_scale.asg_spec.min_size }}"
+  when:
+    - ret_asg.results is defined
+    - ret_asg.results[0].desired_capacity < item_scale.asg_spec.min_size
+
 - name: aws | asg | Create
   ec2_asg: "{{
       asg_spec_local


### PR DESCRIPTION
When ASG `desired` value is defined to an value inferior of `min`, the API return errors.

So, to avoid the errors and making it idempotent when `desired` is too high, we respect the `min` and increase the `desired`. 