### PR TITLE
refact: Added a 'region' variable since not everyone have a region env locally

### DIFF
--- a/tasks/aws-asg-policy/step-config.yml
+++ b/tasks/aws-asg-policy/step-config.yml
@@ -42,6 +42,7 @@
     period: "{{ item_step.alarm_spec.period | d(60) }}"
     evaluation_periods: "{{ item_step.alarm_spec.minutes }}"
     unit: "{{ item_step.alarm_spec.unit |d('Percent') }}"
+    region: "{{ item_scale.region |d(cs_region)}}"
     dimensions:
       AutoScalingGroupName: "{{ item_scale.asg_name }}"
     alarm_actions: "{{ sp_out.PolicyARN }}"


### PR DESCRIPTION
I had some problems on using this role because I didn't have a region var locally. And accordingly to documentation here:

https://docs.ansible.com/ansible/latest/modules/ec2_metric_alarm_module.html

'region' its not required but if not is informed it gives an error:
"msg": "region must be specified"

So I added it to alarm config since we already have it at our disposal