### PR TITLE
fix: delete ENI on termination by default

### DIFF
--- a/vars/launch-template-data.yml
+++ b/vars/launch-template-data.yml
@@ -9,6 +9,6 @@ launch_template_data:
   NetworkInterfaces:
     - DeviceIndex: 0
       AssociatePublicIpAddress: "{{ item_scale.lt_spec.associate_public_ip_address | d('false') | bool }}"
-      DeleteOnTermination: "{{ item_scale.lt_spec.delete_on_termination | d('false') | bool }}"
+      DeleteOnTermination: "{{ item_scale.lt_spec.delete_on_termination | d('true') | bool }}"
       Groups: "{{ item_scale.lt_spec.security_groups }}"
   InstanceType: "{{ item_scale.asg_mixed_instances_policy.instance_types.0 }}"


### PR DESCRIPTION
ENI should be deleted whenever an instance is terminated when using mixed instances policy.