### PR TITLE
Feat/instance weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,10 +279,14 @@ Example Playbook
         - arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/tg-api/abcdef0123456789
 
       cs_asg_instance_types:
-        - c5.large
-        - c5d.large
-        - m5.large
-        - m5d.large
+        - type: c5.large
+          weight: 2
+        - type: c5d.large
+          weight: 1
+        - type: m5.large
+          weight: 2
+        - type: m5d.large
+          weight: 1
 
       cs_asg_availability_zones:
         - us-east-1d

--- a/templates/MixedInstancesPolicy.json.j2
+++ b/templates/MixedInstancesPolicy.json.j2
@@ -5,9 +5,14 @@
                 "Version": "1"
             },
             "Overrides": [
-{% for instance_type in item_scale.asg_mixed_instances_policy.instance_types %}
+{% for instance in item_scale.asg_mixed_instances_policy.instance_types %}
                 {
-                    "InstanceType": "{{ instance_type }}"
+{% if instance is string %}
+                    "InstanceType": "{{ instance }}"
+{% else %}
+                    "InstanceType": "{{ instance.type }}",
+                    "WeightedCapacity": "{{ instance.weight |d(1) }}"
+{% endif %}
 {% if loop.last %}
                 }
 {% else %}


### PR DESCRIPTION
This PR keeps compatibility with old syntax:
```
cs_asg_instance_types:
  - c5.large
  - m5.large
  ...
```