### PR TITLE
fix(asg): convert string to int before comparison

### DIFF
--- a/tasks/aws-asg.yml
+++ b/tasks/aws-asg.yml
@@ -40,7 +40,7 @@
   when:
     - ret_asg.results is defined
     - ret_asg.results|length > 0
-    - ret_asg.results[0].desired_capacity < item_scale.asg_spec.min_size
+    - ret_asg.results[0].desired_capacity < item_scale.asg_spec.min_size|int
 
 - name: aws | asg | create
   ec2_asg: "{{


### PR DESCRIPTION
The task "aws | asg | fix current desired_capacity to >= min"
was raising the following error:
"AnsibleError - '>=' not supported between instances of 'AnsibleUnsafeText' and 'int'"

The comparision beetwen string and int does not work on python 3

ref: https://github.com/ansible/ansible/issues/50388#issuecomment-450812256

To fix it I'm forcing an string conversion to int

